### PR TITLE
Split API endpoint `manual_run_edit` per run attribute

### DIFF
--- a/runregistry_backend/routes/run.js
+++ b/runregistry_backend/routes/run.js
@@ -17,7 +17,13 @@ module.exports = app => {
     auth,
     catchAPI(Run.automatic_run_update)
   );
-  app.put('/manual_run_edit/:run_number', auth, catchAPI(Run.manual_edit));
+
+  // Endpoint for updating run attributes. Initially a single
+  // endpoint, it was later split, in order to give different e-group permissions
+  // to modify different run attributes.
+  // I.e. only experts should be able to modify the run class,
+  // but shifters should be able to modify the stop_reason of the run.
+  app.put('/manual_run_edit/:run_number/:attribute', auth, catchAPI(Run.manual_edit));
 
   // Querying:
   app.post('/runs_filtered_ordered', catchAPI(Run.getRunsFilteredOrdered));
@@ -25,6 +31,6 @@ module.exports = app => {
   // Shifter actions:
   app.post('/runs/mark_significant', auth, catchAPI(Run.markSignificant));
   app.post('/runs/move_run/:from_state/:to_state', auth, catchAPI(Run.moveRun));
-  app.post('/runs/refresh_run/:run_number',           catchAPI(Run.refreshRunClassAndComponents));
+  app.post('/runs/refresh_run/:run_number', catchAPI(Run.refreshRunClassAndComponents));
   app.post('/runs/reset_and_refresh_run/:run_number', catchAPI(Run.resetAndRefreshRunRRatributes));
 };

--- a/runregistry_frontend/.env_sample
+++ b/runregistry_frontend/.env_sample
@@ -2,5 +2,6 @@ ENV=development
 NODE_ENV=development
 
 # Development vars
-DEV_EGROUPS=cms-dqm-runregistry-online-shifters
-DEV_EMAIL=giannopoulos-aggelopoulos@cern.ch
+# The NEXT_PUBLIC_ prefix will make them available in the browser  
+NEXT_PUBLIC_DEV_EGROUPS=cms-dqm-runregistry-experts
+NEXT_PUBLIC_DEV_EMAIL=giannopoulos-aggelopoulos@cern.ch

--- a/runregistry_frontend/components/common/editComponent/EditComponent.js
+++ b/runregistry_frontend/components/common/editComponent/EditComponent.js
@@ -109,7 +109,6 @@ class EditComponent extends Component {
                   this.setState({ loading_submit: true });
                   const { run_number, dataset_name } = this.props;
                   let component_triplet_name = component;
-                  console.log(form_values);
                   await this.props.addLumisectionRange(
                     form_values,
                     run_number,
@@ -123,7 +122,7 @@ class EditComponent extends Component {
                     await this.props.reFetchDataset(run_number, dataset_name);
                   }
                   this.setState({ loading_submit: false });
-                  await Swal(`Component's edited successfully`, '', 'success');
+                  await Swal(`Component edited successfully`, '', 'success');
                 } catch (err) {
                   this.setState({ loading_submit: false });
                   throw err;

--- a/runregistry_frontend/components/online/manage_run/ManageRunModal.js
+++ b/runregistry_frontend/components/online/manage_run/ManageRunModal.js
@@ -12,7 +12,6 @@ class ManageRunModal extends Component {
       children,
       run,
     } = this.props;
-    console.log(manage_run_modal_visible);
     return (
       <div>
         <Modal

--- a/runregistry_frontend/components/online/manage_run/manageRun/editRunAttributes/EditRun.js
+++ b/runregistry_frontend/components/online/manage_run/manageRun/editRunAttributes/EditRun.js
@@ -12,6 +12,16 @@ import { error_handler } from '../../../../../utils/error_handlers';
 const { TextArea } = Input;
 const { Option, OptGroup } = Select;
 
+// Helper function for formatting a list of attributes that 
+// were not updated correctly into an unordered list.
+const format_failed_attributes = (failed_attributes) => {
+    let msg = 'Note: some attributes have not been been updated.<ul>';
+    failed_attributes.forEach(failed_attribute => msg += `<li>You do not have the required permissions to edit the run's ${String(failed_attribute)}</li>`);
+    msg += '</ul>';
+    return msg;
+
+}
+
 class EditRun extends Component {
     state = { classes: [], not_in_the_list: false };
     componentDidMount = error_handler(async () => {
@@ -41,16 +51,10 @@ class EditRun extends Component {
                                 const updated_run = {
                                     rr_attributes: form_values
                                 };
-                                const warnings = await editRun(run.run_number, updated_run);
+                                const failed_attributes = await editRun(run.run_number, updated_run);
                                 await Swal(
-                                    `Run ${run.run_number}'s components edited successfully`,
-                                    warnings ? ((warnings) => {
-                                        let msg = 'Warnings occured when updating run: <ul>';
-                                        warnings.forEach(warning => msg += `<li>${String(warning)}</li>`);
-                                        msg += '</ul>';
-                                        return msg;
-                                    })(warnings) : '',
-
+                                    `Run ${run.run_number}'s attributes edited successfully`,
+                                    failed_attributes.length > 0 ? format_failed_attributes(failed_attributes) : '',
                                     'success'
                                 );
 
@@ -265,6 +269,7 @@ class EditRun extends Component {
                         display: flex;
                         justify-content: flex-end;
                     }
+                
                 `}</style>
             </div>
         );

--- a/runregistry_frontend/components/online/manage_run/manageRun/editRunAttributes/EditRun.js
+++ b/runregistry_frontend/components/online/manage_run/manageRun/editRunAttributes/EditRun.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
+import ReactDOMServer from 'react-dom/server';
 import { connect } from 'react-redux';
 import Swal from 'sweetalert2';
-import { Formik, Field } from 'formik';
-import { Select, Input, Button } from 'antd';
+import { Formik } from 'formik';
+import { Select, Input, Button, Collapse } from 'antd';
 import axios from 'axios';
 import { api_url } from '../../../../../config/config';
 import { editRun } from '../../../../../ducks/online/runs';
@@ -40,12 +41,19 @@ class EditRun extends Component {
                                 const updated_run = {
                                     rr_attributes: form_values
                                 };
-                                await editRun(run.run_number, updated_run);
+                                const warnings = await editRun(run.run_number, updated_run);
                                 await Swal(
-                                    `Run ${run.run_number} component's edited successfully`,
-                                    '',
+                                    `Run ${run.run_number}'s components edited successfully`,
+                                    warnings ? ((warnings) => {
+                                        let msg = 'Warnings occured when updating run: <ul>';
+                                        warnings.forEach(warning => msg += `<li>${String(warning)}</li>`);
+                                        msg += '</ul>';
+                                        return msg;
+                                    })(warnings) : '',
+
                                     'success'
                                 );
+
                             }}
                             render={({
                                 values,

--- a/runregistry_frontend/components/ui/nav/top/TopNav.js
+++ b/runregistry_frontend/components/ui/nav/top/TopNav.js
@@ -116,7 +116,7 @@ class TopNav extends Component {
               'No User Specified in the Headers, or User is Developing'}
           </h3>
 
-          <a className="white" href="https://cmsrunregistry.web.cern.ch/logout">
+          <a className="white" href="/logout">
             Log out
           </a>
         </div>

--- a/runregistry_frontend/ducks/online/lumisections.js
+++ b/runregistry_frontend/ducks/online/lumisections.js
@@ -35,7 +35,6 @@ export const fetchOMSLumisectionRanges = (run_number) =>
 
 export const fetchRRLumisectionRanges = (run_number, dataset_name) =>
   error_handler(async (dispatch) => {
-    console.log('here');
     const {
       data: lumisections,
     } = await axios.post(`${api_url}/lumisections/rr_lumisection_ranges`, {

--- a/runregistry_frontend/utils/error_handlers.js
+++ b/runregistry_frontend/utils/error_handlers.js
@@ -7,37 +7,37 @@ export const error_handler = (
   show_popup = true,
   show_html = false
 ) => (...params) =>
-  fn(...params).catch((err) => {
-    if (axios.isCancel(err)) {
-      // It is a canceled request, not really an error
-      console.log('request canceled due to race condition');
-      return;
-    }
-    console.log(err);
-    let swal_message = {
-      type: 'error',
-      title: 'Error:',
-      text: error_message || err ? err.message : '',
-    };
-    if (err.response) {
-      console.log(err.response);
-      const { status, statusText, data } = err.response;
-      if (show_html) {
-        swal_message.html = data.err;
+    fn(...params).catch((err) => {
+      if (axios.isCancel(err)) {
+        // It is a canceled request, not really an error
+        console.log('request cancelled due to race condition');
+        return;
       }
-      swal_message.text = data.err || `Status code ${status}, ${statusText}`;
-      if (status === 401) {
-        // User has no authorization:
-        swal_message.type = 'warning';
-        swal_message.title = 'You are not authorized to perform this action';
-        swal_message.html = data.message;
+      console.log(err);
+      let swal_message = {
+        type: 'error',
+        title: 'Error:',
+        text: error_message || err ? err.message : '',
+      };
+      if (err.response) {
+        console.log(err.response);
+        const { status, statusText, data } = err.response;
+        if (show_html) {
+          swal_message.html = data.err;
+        }
+        swal_message.text = data.err || `Status code ${status}, ${statusText}`;
+        if (status === 401) {
+          // User has no authorization:
+          swal_message.type = 'warning';
+          swal_message.title = 'You are not authorized to perform this action';
+          swal_message.html = data.message;
+        }
+        if (show_popup === false) {
+          throw swal_message.text;
+        }
       }
-      if (show_popup === false) {
-        throw swal_message.text;
+      if (show_popup) {
+        Swal(swal_message);
       }
-    }
-    if (show_popup) {
-      Swal(swal_message);
-    }
-    throw 'Error';
-  });
+      throw 'Error';
+    });


### PR DESCRIPTION
Resolves #19.

In order to avoid changing the UI, the same form is used to `PUT` two requests, one for each run attribute (`class`, `stop_reason`). 
This leads us to have to check if any of the two succeeded:  if only one succeeded, this means that the request was partially successful, but, due to missing permissions, you could not change all the run attributes. In order not to show a scary warning message to the shifters, partial success is still shown as success, but with a message on what attribute failed to update.

The `error_handler` is only triggered if both requests failed. 

Another solution would be to have separate forms for updating each attribute, but I'd prefer not to change the UI. 