### PR TITLE
Fix cronjob options

### DIFF
--- a/runregistry_backend/app.js
+++ b/runregistry_backend/app.js
@@ -38,7 +38,7 @@ console.error = getLogger("ERROR", console.error)
 
 // Logging for sanity
 const { database, host, port: db_port } = config[process.env.ENV];
-console.error(`Using database: ${database}@${host}:${db_port}`);
+console.info(`Using database: ${database}@${host}:${db_port}`);
 
 models.sequelize.sync({})
   .then(async () => {

--- a/runregistry_backend/config/config.js
+++ b/runregistry_backend/config/config.js
@@ -1,4 +1,4 @@
-// Common configuration used by all deployment modes
+// Common configuration used and overriden by all deployment modes.
 commonVars = {
   // Database config
   username: process.env.DB_USERNAME || 'postgres',
@@ -26,6 +26,7 @@ commonVars = {
   WAITING_DQM_GUI_CONSTANT: 'waiting dqm gui',
   DQM_GUI_URL: 'https://cmsweb.cern.ch/dqm/offline/data/json/samples?match=',
   DQM_GUI_PING_CRON_ENABLED: true,
+  DQM_GUI_CHECK_EVERY_NTH_MINUTE: 60, // This needs to be <=60
   // OMS
   OMS_URL: `https://cmsoms.cern.ch/agg/api/v1`,
   OMS_GET_RUNS_CRON_ENABLED: true, // Get runs from OMS periodically or not
@@ -35,6 +36,7 @@ commonVars = {
   CLIENT_SECRET: process.env.CLIENT_SECRET,
   OMS_AUDIENCE: 'cmsoms-prod',
   RUNS_PER_API_CALL: 49,
+  OMS_API_CALL_EVERY_NTH_MINUTE: 30, // This needs to be <=60
   // Redis
   // redis://:<pass>@<host>:<port>
   REDIS_URL: `redis://${process.env.REDIS_PASSWORD ? ':' + process.env.REDIS_PASSWORD + '@' : ''}${process.env.REDIS_HOST || '127.0.0.1'}:${process.env.REDIS_PORT || 6379}`,
@@ -55,7 +57,7 @@ module.exports = {
     OMS_RUNS: (number_of_runs = 10) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 30,
-    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 6000,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 60,
     JSON_PROCESSING_ENABLED: false,
     OMS_GET_RUNS_CRON_ENABLED: false,
     DQM_GUI_PING_CRON_ENABLED: false
@@ -68,7 +70,7 @@ module.exports = {
     OMS_RUNS: (number_of_runs = 10) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 30,
-    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 6000,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 60,
     OMS_GET_RUNS_CRON_ENABLED: false,
     JSON_PROCESSING_ENABLED: false,
     DQM_GUI_PING_CRON_ENABLED: false
@@ -79,8 +81,8 @@ module.exports = {
     API_URL: 'http://localhost:9500',
     OMS_RUNS: (number_of_runs = 10) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    OMS_API_CALL_EVERY_NTH_MINUTE: 3600,
-    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 3600,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 5,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 10,
   },
   // Old "bare-metal" production
   production: {
@@ -88,8 +90,8 @@ module.exports = {
     API_URL: 'http://localhost:9500',
     OMS_RUNS: (number_of_runs = 15) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    OMS_API_CALL_EVERY_NTH_MINUTE: 180,
-    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 3600,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 3,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 10,
   },
   // Dev kubernetes flavor which means no cronjobs, no JSON processing
   dev_kubernetes: {
@@ -98,7 +100,7 @@ module.exports = {
     OMS_RUNS: (number_of_runs = 49) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 30,
-    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 600,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 60,
     OMS_GET_RUNS_CRON_ENABLED: false,
     JSON_PROCESSING_ENABLED: false,
     DQM_GUI_PING_CRON_ENABLED: false

--- a/runregistry_backend/config/config.js
+++ b/runregistry_backend/config/config.js
@@ -32,6 +32,9 @@ commonVars = {
   OMS_GET_RUNS_CRON_ENABLED: true, // Get runs from OMS periodically or not
   OMS_SPECIFIC_RUN: (run_number) => `runs?filter[run_number]=${run_number}`,
   OMS_LUMISECTIONS: (run_number) => `lumisections?filter[run_number]=${run_number}&page[limit]=5000`,
+  // The default value here does not play a role, really, it's overridden by OMS_RUNS_PER_API_CALL
+  OMS_RUNS_ENDPOINT: (number_of_runs = 15) =>
+    `runs?sort=-last_update&page[limit]=${number_of_runs}`,
   CLIENT_ID: 'rr-api-client',
   CLIENT_SECRET: process.env.CLIENT_SECRET,
   OMS_AUDIENCE: 'cmsoms-prod',
@@ -54,8 +57,6 @@ module.exports = {
     ...commonVars,
     API_URL: process.env.DOCKER_POSTGRES ? 'http://dev:9500' :
       'http://localhost:9500',
-    OMS_RUNS: (number_of_runs = 10) =>
-      `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 30,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 60,
     JSON_PROCESSING_ENABLED: false,
@@ -67,8 +68,6 @@ module.exports = {
     ...commonVars,
     API_URL: process.env.DOCKER_POSTGRES ? 'http://dev:9500' :
       'http://localhost:9500',
-    OMS_RUNS: (number_of_runs = 10) =>
-      `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 30,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 60,
     OMS_GET_RUNS_CRON_ENABLED: false,
@@ -79,8 +78,6 @@ module.exports = {
   staging: {
     ...commonVars,
     API_URL: 'http://localhost:9500',
-    OMS_RUNS: (number_of_runs = 10) =>
-      `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 5,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 10,
   },
@@ -88,8 +85,6 @@ module.exports = {
   production: {
     ...commonVars,
     API_URL: 'http://localhost:9500',
-    OMS_RUNS: (number_of_runs = 15) =>
-      `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 3,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 10,
   },
@@ -97,8 +92,6 @@ module.exports = {
   dev_kubernetes: {
     ...commonVars,
     API_URL: 'http://runregistry-backend:9500',
-    OMS_RUNS: (number_of_runs = 49) =>
-      `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 30,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 60,
     OMS_GET_RUNS_CRON_ENABLED: false,
@@ -109,8 +102,6 @@ module.exports = {
   staging_kubernetes: {
     ...commonVars,
     API_URL: 'http://runregistry-backend:9500',
-    OMS_RUNS: (number_of_runs = 15) =>
-      `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 10,
     OMS_RUNS_PER_API_CALL: 25,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 15,
@@ -119,10 +110,8 @@ module.exports = {
   prod_kubernetes: {
     ...commonVars,
     API_URL: 'http://runregistry-backend:9500',
-    OMS_RUNS: (number_of_runs = 15) =>
-      `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_RUNS_PER_API_CALL: 49,
-    OMS_API_CALL_EVERY_NTH_MINUTE: 3,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 2,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 10,
   },
 

--- a/runregistry_backend/config/config.js
+++ b/runregistry_backend/config/config.js
@@ -20,6 +20,8 @@ commonVars = {
     idle: 20000,
     acquire: 2000000,
   },
+  // Ignore run numbers lower than this one
+  MINIMUM_CMS_RUN_NUMBER: 100000,
   // DQMGUI
   WAITING_DQM_GUI_CONSTANT: 'waiting dqm gui',
   DQM_GUI_URL: 'https://cmsweb.cern.ch/dqm/offline/data/json/samples?match=',

--- a/runregistry_backend/config/config.js
+++ b/runregistry_backend/config/config.js
@@ -54,8 +54,8 @@ module.exports = {
       'http://localhost:9500',
     OMS_RUNS: (number_of_runs = 10) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    SECONDS_PER_API_CALL: 30,
-    SECONDS_PER_DQM_GUI_CHECK: 6000,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 30,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 6000,
     JSON_PROCESSING_ENABLED: false,
     OMS_GET_RUNS_CRON_ENABLED: false,
     DQM_GUI_PING_CRON_ENABLED: false
@@ -67,8 +67,8 @@ module.exports = {
       'http://localhost:9500',
     OMS_RUNS: (number_of_runs = 10) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    SECONDS_PER_API_CALL: 30,
-    SECONDS_PER_DQM_GUI_CHECK: 6000,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 30,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 6000,
     OMS_GET_RUNS_CRON_ENABLED: false,
     JSON_PROCESSING_ENABLED: false,
     DQM_GUI_PING_CRON_ENABLED: false
@@ -79,8 +79,8 @@ module.exports = {
     API_URL: 'http://localhost:9500',
     OMS_RUNS: (number_of_runs = 10) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    SECONDS_PER_API_CALL: 3600,
-    SECONDS_PER_DQM_GUI_CHECK: 3600,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 3600,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 3600,
   },
   // Old "bare-metal" production
   production: {
@@ -88,8 +88,8 @@ module.exports = {
     API_URL: 'http://localhost:9500',
     OMS_RUNS: (number_of_runs = 15) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    SECONDS_PER_API_CALL: 180,
-    SECONDS_PER_DQM_GUI_CHECK: 3600,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 180,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 3600,
   },
   // Dev kubernetes flavor which means no cronjobs, no JSON processing
   dev_kubernetes: {
@@ -97,8 +97,8 @@ module.exports = {
     API_URL: 'http://runregistry-backend:9500',
     OMS_RUNS: (number_of_runs = 49) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    SECONDS_PER_API_CALL: 30,
-    SECONDS_PER_DQM_GUI_CHECK: 600,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 30,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 600,
     OMS_GET_RUNS_CRON_ENABLED: false,
     JSON_PROCESSING_ENABLED: false,
     DQM_GUI_PING_CRON_ENABLED: false
@@ -109,8 +109,8 @@ module.exports = {
     API_URL: 'http://runregistry-backend:9500',
     OMS_RUNS: (number_of_runs = 15) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    SECONDS_PER_API_CALL: 60,
-    SECONDS_PER_DQM_GUI_CHECK: 600,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 10,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 15,
   },
   // Production config for kubernetes
   prod_kubernetes: {
@@ -118,8 +118,8 @@ module.exports = {
     API_URL: 'http://runregistry-backend:9500',
     OMS_RUNS: (number_of_runs = 15) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
-    SECONDS_PER_API_CALL: 180,
-    SECONDS_PER_DQM_GUI_CHECK: 3600,
+    OMS_API_CALL_EVERY_NTH_MINUTE: 3,
+    DQM_GUI_CHECK_EVERY_NTH_MINUTE: 10,
   },
 
   // The online components are also the rr_lumisection_whitelist

--- a/runregistry_backend/config/config.js
+++ b/runregistry_backend/config/config.js
@@ -35,7 +35,7 @@ commonVars = {
   CLIENT_ID: 'rr-api-client',
   CLIENT_SECRET: process.env.CLIENT_SECRET,
   OMS_AUDIENCE: 'cmsoms-prod',
-  RUNS_PER_API_CALL: 49,
+  OMS_RUNS_PER_API_CALL: 49,
   OMS_API_CALL_EVERY_NTH_MINUTE: 30, // This needs to be <=60
   // Redis
   // redis://:<pass>@<host>:<port>
@@ -112,6 +112,7 @@ module.exports = {
     OMS_RUNS: (number_of_runs = 15) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
     OMS_API_CALL_EVERY_NTH_MINUTE: 10,
+    OMS_RUNS_PER_API_CALL: 25,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 15,
   },
   // Production config for kubernetes
@@ -120,6 +121,7 @@ module.exports = {
     API_URL: 'http://runregistry-backend:9500',
     OMS_RUNS: (number_of_runs = 15) =>
       `runs?sort=-last_update&page[limit]=${number_of_runs}`,
+    OMS_RUNS_PER_API_CALL: 49,
     OMS_API_CALL_EVERY_NTH_MINUTE: 3,
     DQM_GUI_CHECK_EVERY_NTH_MINUTE: 10,
   },

--- a/runregistry_backend/cron/1.get_runs.js
+++ b/runregistry_backend/cron/1.get_runs.js
@@ -9,7 +9,7 @@ const {
   OMS_RUNS,
   OMS_GET_RUNS_CRON_ENABLED,
   API_URL,
-  RUNS_PER_API_CALL,
+  OMS_RUNS_PER_API_CALL,
   OMS_API_CALL_EVERY_NTH_MINUTE,
   MINIMUM_CMS_RUN_NUMBER
 } = config[process.env.ENV || 'development'];
@@ -24,7 +24,7 @@ const instance = axios.create({
 
 // Will call itself recursively if all runs are new
 const fetch_runs = async (
-  fetch_amount = RUNS_PER_API_CALL,
+  fetch_amount = OMS_RUNS_PER_API_CALL,
   first_time = true
 ) => {
   const oms_url = `${OMS_URL}/${OMS_RUNS(fetch_amount)}`;
@@ -41,7 +41,7 @@ const fetch_runs = async (
       setTimeout(resolve, 2000);
     });
   }
-
+  console.debug(`Fetching the ${OMS_RUNS(fetch_amount)} last updated OMS runs`)
   const oms_response = await instance.get(oms_url, {
     headers,
   });
@@ -58,7 +58,7 @@ const fetch_runs = async (
   let fetched_runs = first_time
     ? all_fetched_runs
     : all_fetched_runs.slice(fetch_amount / 2);
-  console.debug("Querying the last 50 updated OMS runs")
+  console.debug("Querying the last 50 updated RR runs")
   const { data: last_saved_runs } = await axios.get(
     `${API_URL}/runs_lastupdated_50`
   );

--- a/runregistry_backend/cron/1.get_runs.js
+++ b/runregistry_backend/cron/1.get_runs.js
@@ -41,7 +41,7 @@ const fetch_runs = async (
       setTimeout(resolve, 2000);
     });
   }
-  console.debug(`Fetching the ${OMS_RUNS(fetch_amount)} last updated OMS runs`)
+  console.debug(`Fetching the ${fetch_amount} last updated OMS runs`)
   const oms_response = await instance.get(oms_url, {
     headers,
   });

--- a/runregistry_backend/cron/1.get_runs.js
+++ b/runregistry_backend/cron/1.get_runs.js
@@ -10,7 +10,8 @@ const {
   OMS_GET_RUNS_CRON_ENABLED,
   API_URL,
   RUNS_PER_API_CALL,
-  SECONDS_PER_API_CALL,
+  OMS_API_CALL_EVERY_NTH_MINUTE,
+  MINIMUM_CMS_RUN_NUMBER
 } = config[process.env.ENV || 'development'];
 const { save_runs, update_runs } = require('./2.save_or_update_runs');
 
@@ -95,7 +96,7 @@ const fetch_runs = async (
 
 if (OMS_GET_RUNS_CRON_ENABLED === true) {
   const job = new CronJob(
-    `*/${SECONDS_PER_API_CALL} * * * * *`,
+    `*/${OMS_API_CALL_EVERY_NTH_MINUTE} * * * *`,
     handleErrors(fetch_runs, 'cron/1.get_runs.js # Error fetching new runs ')
   ).start();
 }

--- a/runregistry_backend/cron/1.get_runs.js
+++ b/runregistry_backend/cron/1.get_runs.js
@@ -6,7 +6,7 @@ const https = require('https');
 const config = require('../config/config');
 const {
   OMS_URL,
-  OMS_RUNS,
+  OMS_RUNS_ENDPOINT,
   OMS_GET_RUNS_CRON_ENABLED,
   API_URL,
   OMS_RUNS_PER_API_CALL,
@@ -27,9 +27,9 @@ const fetch_runs = async (
   fetch_amount = OMS_RUNS_PER_API_CALL,
   first_time = true
 ) => {
-  const oms_url = `${OMS_URL}/${OMS_RUNS(fetch_amount)}`;
-  // insert cookie that will authenticate OMS request:
+  const oms_url = `${OMS_URL}/${OMS_RUNS_ENDPOINT(fetch_amount)}`;
 
+  // insert cookie that will authenticate OMS request:
   if (first_time) {
     headers = {
       Authorization: `Bearer ${await getToken()}`,

--- a/runregistry_backend/cron/1.get_runs.js
+++ b/runregistry_backend/cron/1.get_runs.js
@@ -140,7 +140,12 @@ const calculate_runs_to_update = (fetched_runs, last_saved_runs) => {
   fetched_runs.forEach((fetched_run) => {
     // If the run_number is less than the minimum of the already saved runs, then it is one from the past, which needs to be updated. Else we compare timestamps
     if (fetched_run.run_number < min_run_number) {
-      runs_to_update.push(fetched_run);
+      if (fetched_run.run_number > MINIMUM_CMS_RUN_NUMBER) {
+        runs_to_update.push(fetched_run);
+
+      } else {
+        console.log(`Run number ${fetched_run.run_number} is lower than the threshold MINIMUM_CMS_RUN_NUMBER (${MINIMUM_CMS_RUN_NUMBER}), ignoring`)
+      }
     } else {
       // If the run_number is inside the existing already saved runs, then we check for the timestamp:
       last_saved_runs.forEach((existing_run) => {

--- a/runregistry_backend/cron/1.get_runs.js
+++ b/runregistry_backend/cron/1.get_runs.js
@@ -57,7 +57,7 @@ const fetch_runs = async (
   let fetched_runs = first_time
     ? all_fetched_runs
     : all_fetched_runs.slice(fetch_amount / 2);
-
+  console.debug("Querying the last 50 updated OMS runs")
   const { data: last_saved_runs } = await axios.get(
     `${API_URL}/runs_lastupdated_50`
   );

--- a/runregistry_backend/cron/saving_updating_runs_lumisections_utils.js
+++ b/runregistry_backend/cron/saving_updating_runs_lumisections_utils.js
@@ -28,6 +28,7 @@ exports.get_OMS_lumisections = handleErrors(async (run_number) => {
   await new Promise((resolve) => {
     setTimeout(resolve, 2000);
   });
+  console.debug(`Requesting lumisections for run ${run_number} from OMS`)
   const oms_lumisection_url = `${OMS_URL}/${OMS_LUMISECTIONS(run_number)}`;
   // Keep fetching until totalresourcecount is # of lumisections
   const oms_lumisection_response = await instance

--- a/runregistry_backend/cron_datasets/2.ping_dqm_gui.js
+++ b/runregistry_backend/cron_datasets/2.ping_dqm_gui.js
@@ -24,7 +24,7 @@ const { handleErrors } = require('../utils/error_handlers');
 const {
   API_URL,
   DQM_GUI_URL,
-  SECONDS_PER_DQM_GUI_CHECK,
+  DQM_GUI_CHECK_EVERY_NTH_MINUTE,
   WAITING_DQM_GUI_CONSTANT,
   DQM_GUI_PING_CRON_ENABLED
 } = require('../config/config')[process.env.ENV || 'development'];
@@ -231,7 +231,7 @@ const ping_dqm_gui = async () => {
 // Cron job starts:
 if (DQM_GUI_PING_CRON_ENABLED === true) {
   const job = new CronJob(
-    `*/${SECONDS_PER_DQM_GUI_CHECK} * * * * *`,
+    `*/${DQM_GUI_CHECK_EVERY_NTH_MINUTE} * * * *`,
     handleErrors(ping_dqm_gui, 'cron_datasets/2.ping_dqm_gui.js # Error pinging DQM GUI')
   ).start();
 } else {


### PR DESCRIPTION
The cronjob library was not working given the configuration it was being passed, e.g., a `*/3600 * * * * *` crontab was expected to run every 1 hour, but the `node-cron` library was ignoring any value greater than 60 and it was running every 1 minute. 

This PR makes the cronjob options in `config.js` modify the minute part of the crontab instead, as there's no way that a query to OMS for the latest runs would need to be run more frequently than every 1 minute from our side.

Variable names are updated to reflect their purpose. 

Extra logging is also added