### PR TITLE
Add prescale info in the information stored from OMS

### DIFF
--- a/runregistry_backend/config/config.js
+++ b/runregistry_backend/config/config.js
@@ -172,6 +172,7 @@ module.exports = {
       'beam1_stable', 'hbhec_ready',
       'beam2_stable', 'beam2_present',
       'gemp_ready', 'gemm_ready',
+      'prescale_index', 'prescale_name'
     ],
   oms_lumisection_luminosity_whitelist:
     [


### PR DESCRIPTION
- Now `prescale_index` and `prescale_name` are kept when storing OMS attributes.