### PR TITLE
Renamed functions and vars to make their uses clearer

### DIFF
--- a/runregistry_backend/controllers/run.js
+++ b/runregistry_backend/controllers/run.js
@@ -250,7 +250,7 @@ exports.new = async (req, res) => {
   } catch (err) {
     console.error("run.js # new(): ", err);
     await transaction.rollback();
-    throw `Error saving run ${run_number}`;
+    throw `Error saving run ${run_number}: ${err}`;
   }
 };
 

--- a/runregistry_backend/cron/2.save_or_update_runs.js
+++ b/runregistry_backend/cron/2.save_or_update_runs.js
@@ -6,9 +6,9 @@ const {
   get_OMS_lumisections,
 } = require('./saving_updating_runs_lumisections_utils');
 const {
-  calculate_rr_attributes,
-  calculate_rr_lumisections,
-  calculate_oms_attributes,
+  calculate_updated_rr_run_attributes,
+  classify_rr_lumisection_components,
+  augment_oms_run_attributes,
 } = require('./3.calculate_rr_attributes');
 
 const { API_URL, OMS_URL, OMS_SPECIFIC_RUN } = require('../config/config')[
@@ -37,17 +37,17 @@ exports.save_runs = async (new_runs, number_of_tries) => {
       // delete run.lumisections;
       // END temporal:
 
-      const oms_attributes = await calculate_oms_attributes(
+      const oms_run_attributes = await augment_oms_run_attributes(
         run,
         oms_lumisections
       );
 
       // We freeze oms_attributes to prevent them changing later on:
       Object.freeze(oms_lumisections);
-      Object.freeze(oms_attributes);
+      Object.freeze(oms_run_attributes);
       // NORMAL:
-      const rr_attributes = await calculate_rr_attributes(
-        oms_attributes,
+      const rr_run_attributes = await calculate_updated_rr_run_attributes(
+        oms_run_attributes,
         oms_lumisections
       );
       // START TEMPORAL
@@ -55,10 +55,10 @@ exports.save_runs = async (new_runs, number_of_tries) => {
       // END TEMPORAL
       let rr_lumisections = [];
       // Only if the run is significant, do we calculate the component statuses for the run
-      if (rr_attributes.significant) {
-        rr_lumisections = await calculate_rr_lumisections(
-          oms_attributes,
-          rr_attributes,
+      if (rr_run_attributes.significant) {
+        rr_lumisections = await classify_rr_lumisection_components(
+          oms_run_attributes,
+          rr_run_attributes,
           oms_lumisections
         );
       }
@@ -66,9 +66,9 @@ exports.save_runs = async (new_runs, number_of_tries) => {
       await axios.post(
         `${API_URL}/runs`,
         {
-          oms_attributes,
+          oms_attributes: oms_run_attributes,
           oms_lumisections,
-          rr_attributes,
+          rr_attributes: rr_run_attributes,
           rr_lumisections,
         },
         {
@@ -133,39 +133,41 @@ exports.update_runs = (
   return new Promise(async (resolve, reject) => {
     let updated_runs = 0;
     const runs_not_updated = [];
-    const promises = runs_to_update.map((run) => async () => {
+    const promises = runs_to_update.map((oms_run_attributes) => async () => {
       // We only update a run which state is OPEN
       try {
-        // We get the lumisections from OMS:
-        const oms_lumisections = await get_OMS_lumisections(run.run_number);
-        const oms_attributes = await calculate_oms_attributes(
-          run,
+        // We get per-lumisection info from OMS
+        const oms_lumisections = await get_OMS_lumisections(oms_run_attributes.run_number);
+        // Then we use it to augment oms run information with attributes we need, such as "pixel_included"
+        oms_run_attributes = await augment_oms_run_attributes(
+          oms_run_attributes,
           oms_lumisections
         );
-        // We freeze oms_attributes to prevent them changing later on:
+        // We freeze oms_attributes to prevent them changing later on
         Object.freeze(oms_lumisections);
-        Object.freeze(oms_attributes);
-        const rr_attributes = await calculate_rr_attributes(
-          oms_attributes,
+        Object.freeze(oms_run_attributes);
+
+        const rr_run_attributes = await calculate_updated_rr_run_attributes(
+          oms_run_attributes,
           oms_lumisections,
           previous_rr_attributes // If it was manually updated (see method below), this will not be undefined
         );
         let rr_lumisections = [];
-        // Only if the run is significant, do we calculate the component statuses for the run
-        if (rr_attributes.significant || manually_significant) {
-          rr_lumisections = await calculate_rr_lumisections(
-            oms_attributes,
-            rr_attributes,
+        // Only calculate the component statuses for the run if the run is significant
+        if (rr_run_attributes.significant || manually_significant) {
+          rr_lumisections = await classify_rr_lumisection_components(
+            oms_run_attributes,
+            rr_run_attributes,
             oms_lumisections
           );
         }
-        console.debug(`Updating attributes for run ${oms_attributes['run_number']}, via PUT`)
+        console.debug(`Updating attributes for run ${oms_run_attributes['run_number']}, via PUT`)
         const updated_run = await axios.put(
-          `${API_URL}/automatic_run_update/${run.run_number}`,
+          `${API_URL}/automatic_run_update/${oms_run_attributes.run_number}`,
           {
-            oms_attributes,
-            oms_lumisections,
-            rr_attributes,
+            oms_attributes: oms_run_attributes,
+            oms_lumisections: oms_lumisections,
+            rr_attributes: rr_run_attributes,
             rr_lumisections,
             atomic_version,
           },
@@ -186,7 +188,7 @@ exports.update_runs = (
           updated_runs += 1;
         }
       } catch (e) {
-        console.log(`2.save_or_update_runs.js # update_runs(): Error updating run ${run.run_number}`);
+        console.error(`2.save_or_update_runs.js # update_runs(): Error updating run ${oms_run_attributes.run_number}, ${e}`);
       }
     });
     if (runs_to_update.length < 10) {
@@ -257,8 +259,8 @@ exports.manually_update_a_run = async (
       Authorization: `Bearer ${await getToken()}`,
     },
   });
-  const run_oms_attributes = fetched_run[0].attributes;
-  await exports.update_runs([run_oms_attributes], 0, {
+  const oms_run_attributes = fetched_run[0].attributes;
+  await exports.update_runs([oms_run_attributes], 0, {
     previous_rr_attributes,
     email,
     comment,
@@ -288,8 +290,8 @@ exports.manually_update_a_run_reset_rr_attributes = async (
     },
   });
   const empty_var = false;
-  const run_oms_attributes = fetched_run[0].attributes;
-  await exports.update_runs([run_oms_attributes], 0, {
+  const oms_run_attributes = fetched_run[0].attributes;
+  await exports.update_runs([oms_run_attributes], 0, {
     empty_var,
     email,
     comment,

--- a/runregistry_backend/cron/3.calculate_rr_attributes.js
+++ b/runregistry_backend/cron/3.calculate_rr_attributes.js
@@ -7,13 +7,17 @@ const {
   assign_lumisection_component_status,
 } = require('./saving_updating_runs_lumisections_utils');
 
-exports.calculate_oms_attributes = async (run, lumisections) => {
+// Using the per-LS OMS attributes, we construct new attributes, to be stored
+// in the newly created object, "oms_attributes", such as "pixel_included" if "PIXEL" was found in run.components.
+// "beams_present_and_stable" is also added to the returned object.
+exports.augment_oms_run_attributes = async (run, lumisections) => {
   const components_included_in_run = getComponentsIncludedBooleans(run);
+  // Deconstruct all the attributes inside the new object.
   const oms_attributes = {
     ...run,
     ...components_included_in_run,
   };
-  // 'beams_present_and_stable'  will only be true if there is at least 1 LS with all other true
+  // 'beams_present_and_stable' will only be true if there is at least 1 LS with all other true
   oms_attributes.beams_present_and_stable = get_beam_present_and_stable(
     lumisections
   );
@@ -21,39 +25,46 @@ exports.calculate_oms_attributes = async (run, lumisections) => {
   return oms_attributes;
 };
 
-exports.calculate_rr_attributes = async (
-  oms_attributes,
+// Given fresh information from OMS for the run and its lumisections,
+// re-classify the run and check if it's significant or not.
+// If we're given existing RR attributes, we preserve them.
+// Return an ojb
+exports.calculate_updated_rr_run_attributes = async (
+  oms_run_attributes,
   oms_lumisections,
-  previous_rr_attributes
+  previous_rr_run_attributes
 ) => {
-  let rr_attributes = {};
-  // Significant starts being false, class is to be determined later:
-  rr_attributes.significant = false;
-  rr_attributes.class = '';
+  let rr_run_attributes = {};
+  // Significant starts being false, class is to be determined later
+  rr_run_attributes.significant = false;
+  rr_run_attributes.class = '';
   // However, if it is a refresh ('update_runs' from 2.save_or_update_runs), we want to preserve the previous values of the run and only recalculate the class and if the run was significant:
-  if (previous_rr_attributes) {
-    rr_attributes = previous_rr_attributes;
+  if (previous_rr_run_attributes) {
+    rr_run_attributes = previous_rr_run_attributes;
   }
 
-  // hlt_key is determinant to calculate the run's class, so if its not ready, we rather wait to classify a run into cosmics, collisions
-  if (oms_attributes.hlt_key !== null) {
-    rr_attributes.class = await assign_run_class(
-      oms_attributes,
-      rr_attributes,
+  // hlt_key is necessary to calculate the run's class, so if its not available skip run classification
+  if (oms_run_attributes.hlt_key !== null) {
+    rr_run_attributes.class = await assign_run_class(
+      oms_run_attributes,
+      rr_run_attributes,
       oms_lumisections
     );
   }
   // Class is needed to determine significance of run, so it is calculated before
-  rr_attributes.significant = await is_run_significant(
-    oms_attributes,
-    rr_attributes,
+  // TODO: What happens if hlt_key was null, and there's no class assigned at this point?
+  // is_run_significant requires it.
+  let run_was_previously_significant = rr_run_attributes.significant;
+  rr_run_attributes.significant = await is_run_significant(
+    oms_run_attributes,
+    rr_run_attributes,
     oms_lumisections
   );
 
-  return rr_attributes;
+  return rr_run_attributes;
 };
 
-exports.calculate_rr_lumisections = async (
+exports.classify_rr_lumisection_components = async (
   oms_attributes,
   rr_attributes,
   oms_lumisections

--- a/runregistry_backend/cron/saving_updating_runs_lumisections_utils.js
+++ b/runregistry_backend/cron/saving_updating_runs_lumisections_utils.js
@@ -188,18 +188,21 @@ exports.assign_run_class = handleErrors(
   },
   'runregistry_backend/cron/saving_updating_runs_lumisections_utils.js # assign_run_class(): Error assigning run class'
 );
-
+// For a given run's OMS and RR attributes, and OMS LS information,
+// try to decide whether it's significant or not.
+// NOTE: "dataset classifiers" in this context have nothing to do with
+// Offline's "datasets" like "Express" etc. It's unknown why this name was chosen
+// (Perhaps it makes sense in the Offline part of Runregistry?)
 exports.is_run_significant = handleErrors(
-  async (oms_attributes, rr_attributes, oms_lumisections) => {
+  async (oms_run_attributes, rr_run_attributes, oms_lumisections) => {
     const reduced_lumisection_attributes = exports.reduce_ls_attributes(
       oms_lumisections
     );
     const run = {
       ...reduced_lumisection_attributes,
-      ...oms_attributes,
-      ...rr_attributes,
+      ...oms_run_attributes,
+      ...rr_run_attributes,
     };
-    let run_is_significant = false;
     const { data: classifiers_array } = await axios.get(
       `${API_URL}/classifiers/dataset`
     );

--- a/runregistry_backend/models/component_classifier.js
+++ b/runregistry_backend/models/component_classifier.js
@@ -22,7 +22,7 @@ module.exports = (sequelize, DataTypes) => {
       updated_by: { type: DataTypes.TEXT, allowNull: true },
     },
     {
-      // the RR DB was created and filled only with createdAt field. But for the operation we need updatedAt instead, actually. 
+      // the RR DB was created and filled only with createdAt field. But for the operation we need updatedAt instead, actually.
       // So, we alias updatedAt as createdAt for sequelize that will update it properly.
       createdAt: false,
       updatedAt: 'createdAt',

--- a/runregistry_backend/test/significant_test.js
+++ b/runregistry_backend/test/significant_test.js
@@ -6,9 +6,9 @@ const {
   get_OMS_lumisections
 } = require('../cron/saving_updating_runs_lumisections_utils');
 const {
-  calculate_rr_attributes,
-  calculate_rr_lumisections,
-  calculate_oms_attributes
+  calculate_updated_rr_run_attributes,
+  classify_rr_lumisection_components,
+  augment_oms_run_attributes: augment_oms_run_attributes
 } = require('../cron/3.calculate_rr_attributes');
 
 describe('Significant test', async () => {
@@ -170,14 +170,14 @@ describe('Significant test', async () => {
   it('Generates significance correctly', async () => {
     // const oms_lumisections = await get_OMS_lumisections(run.run_number);
     const oms_lumisections = [];
-    const oms_attributes = await calculate_oms_attributes(
+    const oms_attributes = await augment_oms_run_attributes(
       run,
       oms_lumisections
     );
     Object.freeze(oms_lumisections);
     Object.freeze(oms_attributes);
 
-    const rr_attributes = await calculate_rr_attributes(
+    const rr_attributes = await calculate_updated_rr_run_attributes(
       oms_attributes,
       oms_lumisections
     );


### PR DESCRIPTION
Several functions were found to have names which
were not very descriptive (i.e., very generic)
of what they were doing. This commit attempts to
make them a bit more specific at the cost of being more verbose and consistent.