### PR TITLE
Replace deprecated react attributes

### DIFF
--- a/runregistry_frontend/components/common/CommonTableComponents/lumisectionModal/LumisectionModal.js
+++ b/runregistry_frontend/components/common/CommonTableComponents/lumisectionModal/LumisectionModal.js
@@ -19,7 +19,7 @@ class LumisectionModal extends Component {
             <div>
                 <Modal
                     title={`Lumisections of run # ${run_number} from ${name}`}
-                    visible={lumisection_modal_visible}
+                    open={lumisection_modal_visible}
                     onOk={hideLumisectionModal}
                     onCancel={
                         hideLumisectionModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/json/configuration/JSONModal.js
+++ b/runregistry_frontend/components/json/configuration/JSONModal.js
@@ -22,7 +22,7 @@ class ConfigurationModal extends Component {
             <div>
                 <Modal
                     title={title_types[modal_type]}
-                    visible={modal_visible}
+                    open={modal_visible}
                     onOk={hideModal}
                     onCancel={
                         hideModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/json_portal/configuration/JSONModal.js
+++ b/runregistry_frontend/components/json_portal/configuration/JSONModal.js
@@ -22,7 +22,7 @@ class JSONConfigurationModal extends Component {
       <div>
         <Modal
           title={title_types[modal_type]}
-          visible={modal_visible}
+          open={modal_visible}
           onOk={hideModal}
           onCancel={
             hideModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/json_portal/configuration/json_configuration/JSONConfiguration.js
+++ b/runregistry_frontend/components/json_portal/configuration/json_configuration/JSONConfiguration.js
@@ -251,7 +251,7 @@ class Configuration extends Component {
                 Enter the dataset of the runs you want to create a json from:
               </h4>
               <AutoComplete
-                dropdownClassName="certain-category-search-dropdown"
+                popupClassName="certain-category-search-dropdown"
                 dropdownMatchSelectWidth={650}
                 style={{ width: 800 }}
                 options={options}
@@ -289,21 +289,21 @@ class Configuration extends Component {
                   borderRadius: '2px',
                 }}
               >
-                  <Menu onClick={({ key }) => this.handleMenuChange(key)} selectedKeys={[menu_selection]} mode="horizontal">
-                    <Menu.Item key="arbitrary"> New Configuration </Menu.Item>
-                  </Menu>
-                  &nbsp;
-                  <Dropdown overlay={ <Menu style={{ overflowY: 'scroll', maxHeight: '300px' }} onClick={({ key }) => this.handleMenuChange(key)} selectedKeys={[menu_selection]}> 
-                                      {json_configurations_array.filter( ({ created_by }) => created_by === this.props.email).map(({ name }) => ( <Menu.Item key={name}>{name}</Menu.Item> ))}
-                                      </Menu> } destroyPopupOnHide={true}> 
-                    <a style={{ marginTop: '12px' }} className="ant-dropdown-link" onClick={e => e.preventDefault()}> My Configurations <DownOutlined /> </a>
-                  </Dropdown>
-                  &nbsp;
-                  <Dropdown overlay={ <Menu style={{ overflowY: 'scroll', maxHeight: '300px' }} onClick={({ key }) => this.handleMenuChange(key)} selectedKeys={[menu_selection]}> 
-                                      {json_configurations_array.map(({ name }) => ( <Menu.Item key={name}>{name}</Menu.Item>))} 
-                                      </Menu> } destroyPopupOnHide={true}> 
-                    <a style={{ marginTop: '12px' }} className="ant-dropdown-link" onClick={e => e.preventDefault()}> All Configurations <DownOutlined /> </a>
-                  </Dropdown>
+                <Menu onClick={({ key }) => this.handleMenuChange(key)} selectedKeys={[menu_selection]} mode="horizontal">
+                  <Menu.Item key="arbitrary"> New Configuration </Menu.Item>
+                </Menu>
+                &nbsp;
+                <Dropdown overlay={<Menu style={{ overflowY: 'scroll', maxHeight: '300px' }} onClick={({ key }) => this.handleMenuChange(key)} selectedKeys={[menu_selection]}>
+                  {json_configurations_array.filter(({ created_by }) => created_by === this.props.email).map(({ name }) => (<Menu.Item key={name}>{name}</Menu.Item>))}
+                </Menu>} destroyPopupOnHide={true}>
+                  <a style={{ marginTop: '12px' }} className="ant-dropdown-link" onClick={e => e.preventDefault()}> My Configurations <DownOutlined /> </a>
+                </Dropdown>
+                &nbsp;
+                <Dropdown overlay={<Menu style={{ overflowY: 'scroll', maxHeight: '300px' }} onClick={({ key }) => this.handleMenuChange(key)} selectedKeys={[menu_selection]}>
+                  {json_configurations_array.map(({ name }) => (<Menu.Item key={name}>{name}</Menu.Item>))}
+                </Menu>} destroyPopupOnHide={true}>
+                  <a style={{ marginTop: '12px' }} className="ant-dropdown-link" onClick={e => e.preventDefault()}> All Configurations <DownOutlined /> </a>
+                </Dropdown>
               </div>
             </center>
           )}

--- a/runregistry_frontend/components/json_portal/visualizeLuminosity/subSystemDivision/SubsystemDivision.js
+++ b/runregistry_frontend/components/json_portal/visualizeLuminosity/subSystemDivision/SubsystemDivision.js
@@ -200,7 +200,7 @@ function PieChartAndBarChart({ title, data, runs }) {
       {showModal && (
         <LuminositySourceModal
           label={selectedLabel}
-          visible={showModal}
+          open={showModal}
           hideModal={() => setShowModal(false)}
           runs={runs}
         />

--- a/runregistry_frontend/components/json_portal/visualizeLuminosity/subSystemDivision/luminositySourceModal/LuminositySourceModal.js
+++ b/runregistry_frontend/components/json_portal/visualizeLuminosity/subSystemDivision/luminositySourceModal/LuminositySourceModal.js
@@ -10,7 +10,7 @@ export const LuminositySourceModal = ({ visible, hideModal, label, runs }) => {
     <div>
       <Modal
         title={`Visualizing ${label}`}
-        visible={visible}
+        open={visible}
         onOk={hideModal}
         onCancel={
           hideModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/offline/configuration/ConfigurationModal.js
+++ b/runregistry_frontend/components/offline/configuration/ConfigurationModal.js
@@ -85,7 +85,7 @@ class ConfigurationModal extends Component {
       <div>
         <Modal
           title={title_types[configuration_modal_type]}
-          visible={configuration_modal_visible}
+          open={configuration_modal_visible}
           onOk={hideConfigurationModal}
           onCancel={
             hideConfigurationModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/offline/manage_dataset/ManageDatasetModal.js
+++ b/runregistry_frontend/components/offline/manage_dataset/ManageDatasetModal.js
@@ -16,10 +16,9 @@ class ManageDatasetModal extends Component {
         return (
             <div>
                 <Modal
-                    title={`Managing Dataset # ${dataset.name} of run ${
-                        dataset.run_number
-                    }`}
-                    visible={manage_dataset_modal_visible}
+                    title={`Managing Dataset # ${dataset.name} of run ${dataset.run_number
+                        }`}
+                    open={manage_dataset_modal_visible}
                     onOk={hideManageDatasetModal}
                     onCancel={
                         hideManageDatasetModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/online/classifier_visualization/ClassifierVisualizationModal.js
+++ b/runregistry_frontend/components/online/classifier_visualization/ClassifierVisualizationModal.js
@@ -16,7 +16,7 @@ class ClassifierVisualizationModal extends Component {
             <div>
                 <Modal
                     title={`Classifier Visualization for Run ${run.run_number}`}
-                    visible={classifier_visualization_modal}
+                    open={classifier_visualization_modal}
                     onOk={hideClassifierVisualizationModal}
                     onCancel={
                         hideClassifierVisualizationModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/online/configuration/ConfigurationModal.js
+++ b/runregistry_frontend/components/online/configuration/ConfigurationModal.js
@@ -42,7 +42,7 @@ class ConfigurationModal extends Component {
             <div>
                 <Modal
                     title={title_options[configuration_modal_type]}
-                    visible={configuration_modal_visible}
+                    open={configuration_modal_visible}
                     onOk={hideConfigurationModal}
                     onCancel={
                         hideConfigurationModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/online/manage_run/ManageRunModal.js
+++ b/runregistry_frontend/components/online/manage_run/ManageRunModal.js
@@ -16,7 +16,7 @@ class ManageRunModal extends Component {
       <div>
         <Modal
           title={`Managing Run # ${run.run_number}`}
-          visible={manage_run_modal_visible}
+          open={manage_run_modal_visible}
           onOk={hideManageRunModal}
           onCancel={
             hideManageRunModal // confirmLoading={confirmLoading}

--- a/runregistry_frontend/components/online/manage_run/manageRun/editRunLumisections/EditRunLumisections.js
+++ b/runregistry_frontend/components/online/manage_run/manageRun/editRunLumisections/EditRunLumisections.js
@@ -33,7 +33,7 @@ class EditRunLumisections extends Component {
     this.setState({ lumisections, loading: false });
   });
   render() {
-    const { run, workspaces, addLumisectionRange } = this.props;
+    const { run, workspaces, addLumisectionRange, refreshRun, resetAndRefreshRun, showManageRunModal } = this.props;
     const current_workspace = this.props.workspace.toLowerCase();
     let components = [];
     if (current_workspace === 'global') {
@@ -53,58 +53,57 @@ class EditRunLumisections extends Component {
     }
     return (
       <div>
-
-            <br />
-            <div
-              style={{
-                textAlign: 'center',
-              }}
-            >
-              <Button
-                onClick={async (evt) => {
-                  const { value } = await Swal({
-                    type: 'warning',
-                    title: `If a status was previously edited by a shifter, it will not be updated, it will only change those untouched.`,
-                    text: '',
-                    showCancelButton: true,
-                    confirmButtonText: 'Yes',
-                    reverseButtons: true,
-                  });
-                  if (value) {
-                    const updated_run = await this.props.refreshRun( run.run_number );
-                    await Swal(`Run updated`, '', 'success');
-                    await this.props.showManageRunModal(updated_run);
-                    this.fetchLumisections();
-                  }
-                }}
-                type="primary"
-              >
-                Manually refresh component's statuses
-              </Button>
-              &nbsp;
-              <Button
-                onClick={async (evt) => {
-                  const { value } = await Swal({
-                    type: 'warning',
-                    title: `If a status was previously edited by a shifter, it will not be updated, it will only change those untouched.`,
-                    text: '',
-                    showCancelButton: true,
-                    confirmButtonText: 'Yes',
-                    reverseButtons: true,
-                  });
-                  if (value) {
-                    const updated_run = await this.props.resetAndRefreshRun( run.run_number );
-                    await Swal(`Run updated`, '', 'success');
-                    await this.props.showManageRunModal(updated_run);
-                    this.fetchLumisections();
-                  }
-                }}
-                type="primary"
-              >
-                Reset RR attributes and refresh
-              </Button>
-            </div>
-            <br />
+        <br />
+        <div
+          style={{
+            textAlign: 'center',
+          }}
+        >
+          <Button
+            onClick={async (evt) => {
+              const { value } = await Swal({
+                type: 'warning',
+                title: `If a status was previously edited by a shifter, it will not be updated, it will only change those untouched.`,
+                text: '',
+                showCancelButton: true,
+                confirmButtonText: 'Yes',
+                reverseButtons: true,
+              });
+              if (value) {
+                const updated_run = await refreshRun(run.run_number);
+                await Swal(`Run updated`, '', 'success');
+                await showManageRunModal(updated_run);
+                this.fetchLumisections();
+              }
+            }}
+            type="primary"
+          >
+            Manually refresh component's statuses
+          </Button>
+          &nbsp;
+          <Button
+            onClick={async (evt) => {
+              const { value } = await Swal({
+                type: 'warning',
+                title: `If a status was previously edited by a shifter, it will not be updated, it will only change those untouched.`,
+                text: '',
+                showCancelButton: true,
+                confirmButtonText: 'Yes',
+                reverseButtons: true,
+              });
+              if (value) {
+                const updated_run = await resetAndRefreshRun(run.run_number);
+                await Swal(`Run updated`, '', 'success');
+                await showManageRunModal(updated_run);
+                this.fetchLumisections();
+              }
+            }}
+            type="primary"
+          >
+            Reset RR attributes and refresh
+          </Button>
+        </div>
+        <br />
 
         {run.significant ? (
           <div style={{ overflowX: 'scroll' }}>


### PR DESCRIPTION
Some react attributes raise deprecation warnings
when used with node 14, namely `visible` (replaced with `open`), `dropdownClassName` (replaced with `popupClassName`).

Some props are also destructured directly from `this.props` for clarity.