### PR TITLE
Reject promise if update_runs fails

### DIFF
--- a/runregistry_backend/cron/2.save_or_update_runs.js
+++ b/runregistry_backend/cron/2.save_or_update_runs.js
@@ -189,6 +189,7 @@ exports.update_runs = (
         }
       } catch (e) {
         console.error(`2.save_or_update_runs.js # update_runs(): Error updating run ${oms_run_attributes.run_number}, ${e}`);
+        reject(`${e}`)
       }
     });
     if (runs_to_update.length < 10) {


### PR DESCRIPTION
To avoid returning a "success" message when a user requests a manual run update which fails, the `Promise` is now `reject`ed, returning an error instead.