### PR TITLE
Name another default-exported function (`auth`). 

### DIFF
--- a/runregistry_frontend/auth/auth.js
+++ b/runregistry_frontend/auth/auth.js
@@ -1,4 +1,4 @@
-export default function (getState, comment) {
+export default function auth(getState, comment) {
   const state = getState();
   let email = state.info.email;
   let egroups = state.info.egroups;


### PR DESCRIPTION
Named a function which was missed when #29 was opened.