### PR TITLE
Assert that previously significant run stays significant

### DIFF
--- a/runregistry_backend/cron/3.calculate_rr_attributes.js
+++ b/runregistry_backend/cron/3.calculate_rr_attributes.js
@@ -1,3 +1,4 @@
+const assert = require('assert').strict;
 const appendToAllAttributes = require('append-to-all-attributes');
 const {
   getComponentsIncludedBooleans,
@@ -60,6 +61,14 @@ exports.calculate_updated_rr_run_attributes = async (
     rr_run_attributes,
     oms_lumisections
   );
+
+  // Make sure that if for some reason lumisections disappear
+  // and the run is no longer significant, we don't mess up the run information.
+  // TODO: This is probably not the best place to do this check
+  if (run_was_previously_significant) {
+    assert.deepStrictEqual(rr_run_attributes.significant && oms_lumisections.length !== 0, true,
+      `Run ${oms_run_attributes.run_number} would no longer be deemed significant`)
+  }
 
   return rr_run_attributes;
 };


### PR DESCRIPTION
In some cases, runs which have been deemed significant, based on OMS data that RR receives, suddenly become non-significant after an update, due to data that has been removed or changed from the OMS side. This should, in principle, not happen.

This commit adds such an assertion to throw an Exception if this case arises. Without it, the code continues, and in most cases reaches the point where RR tries to delete data from its database (usually LS info), raising an error (`Lumisections cannot be deleted`). The assertion catches this a bit earlier, stopping with a more appropriate message.

This is probably not ideal, and this check could be placed even earlier.