### PR TITLE
[WIP] Add placeholder info for LS that OMS API does not have

### DIFF
--- a/runregistry_backend/cron/saving_updating_runs_lumisections_utils.js
+++ b/runregistry_backend/cron/saving_updating_runs_lumisections_utils.js
@@ -50,14 +50,25 @@ exports.get_OMS_lumisections = handleErrors(async (run_number) => {
   let oms_lumisections = oms_lumisection_response.data.data;
   // Deconstruct attributes inside oms_lumisections:
   oms_lumisections = oms_lumisections.map(({ attributes }) => attributes);
-
+  // If lumisections are missing, we calculate an offset to offset the missing lumisections
+  // while processing them one by one.
+  let lumi_offset = 0;
+  // Create dummy lumisection objects to replace the missing ones. This is an array of arrays, each one
+  // being a subarray of missing lumisections. E.g. [[missing range 25-30], [missing range 54-60]]
+  let missing_lumi_objects_ranges = [];
   // We add luminosity information
   oms_lumisections = oms_lumisections.map(
     ({ recorded_lumi, delivered_lumi, lumisection_number }, index, oms_lumisections) => {
-      // Check that the index matches the LS number
-      if (index + 1 !== lumisection_number) {
+      // Check that the index matches the LS number (including the offset, in case of missing LS).
+      // If they're not matching, we update the missing lumisection ranges with dummy ones, and
+      // adjust the offset.
+      if (index + 1 + lumi_offset !== lumisection_number) {
         console.warn(`Inconsistency in Run ${run_number}: Lumisection ${index} does not match OMS lumisection_number (${lumisection_number})`)
+        lumi_offset = lumisection_number - index - 1;
+        missing_lumi_objects_ranges.push(Array.from(new Array(lumisection_number - index - 1), (x, i) => { return { 'lumisection_number': i + index + 1 } }))
+        console.log(`Missing LS offset: ${lumi_offset}`)
       }
+
       // If any of them is null, then the per_lumi are all null
       if (recorded_lumi === null || delivered_lumi === null) {
         return {
@@ -97,7 +108,10 @@ exports.get_OMS_lumisections = handleErrors(async (run_number) => {
       };
     }
   );
-
+  // If there are missing lumisections, insert them into the lumisection array.
+  missing_lumi_objects_ranges.forEach(range => {
+    oms_lumisections.splice(range[0].lumisection_number - 1, 0, ...range)
+  })
   return oms_lumisections;
 }, 'runregistry_backend/cron/saving_updating_runs_lumisections_utils.js # get_OMS_lumisections(): Error getting lumisection attributes for the run'
 );


### PR DESCRIPTION
It has been observed that sometimes, the OMS API returns LS information with some of them missing, e.g., a run might have 10 LS but OMS returns 8, with some missing in-between. Usually, those fall in the range of LS that have
`cms_active=false`, but this is not always the case.

This commit adds some placeholder LS information.